### PR TITLE
Allow insert_id in events

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -81,6 +81,7 @@ class Event implements JsonSerializable
         'idfv' => 'string',
         'adid' => 'string',
         'android_id' => 'string',
+        'insert_id' => 'string',
     ];
 
     protected array $keys = [];


### PR DESCRIPTION
This will allow events sent using this package to utilize [Amplitude's deduplication functionality](https://amplitude.com/docs/apis/analytics/http-v2#event-deduplication)